### PR TITLE
Workflows are now shown as red in github if tests fail.

### DIFF
--- a/.github/action/action.yml
+++ b/.github/action/action.yml
@@ -47,5 +47,5 @@ runs:
         docker run --name "robot-tests" \
           --network="host" \
             hsldevcom/jore4-robot:latest \
-              bash -c "robot -v ENV:${{ inputs.test_env }} -v BROWSER:${{ inputs.browser }} --include ${{ inputs.included_tag }} --nostatusrc --outputdir /tests/output /tests"
+              bash -c "robot -v ENV:${{ inputs.test_env }} -v BROWSER:${{ inputs.browser }} --include ${{ inputs.included_tag }} --outputdir /tests/output /tests"
       shell: bash

--- a/.github/workflows/robot_test_env.yml
+++ b/.github/workflows/robot_test_env.yml
@@ -20,9 +20,11 @@ jobs:
           test_env: test
 
       - name: Retrieve test results from docker container
+        if: always()
         run: docker cp robot-tests:/tests/output/. ${{ github.workspace }}/reports/
 
       - name: Expose test results as an artifact
+        if: always()
         uses: actions/upload-artifact@v1
         with:
           name: reports

--- a/.github/workflows/test_e2e_action.yml
+++ b/.github/workflows/test_e2e_action.yml
@@ -1,4 +1,4 @@
-name: Test action for e2e testing
+name: Testing e2e action
 
 on:
   push:

--- a/.github/workflows/trigger_tests_manually.yml
+++ b/.github/workflows/trigger_tests_manually.yml
@@ -30,9 +30,11 @@ jobs:
           included_tag: ${{ github.event.inputs.tag }}
 
       - name: Retrieve test results from docker container
+        if: always()
         run: docker cp robot-tests:/tests/output/. ${{ github.workspace }}/reports/
 
       - name: Expose test results as an artifact
+        if: always()
         uses: actions/upload-artifact@v1
         with:
           name: reports

--- a/README.md
+++ b/README.md
@@ -46,9 +46,11 @@ jobs:
           backend_version: #which docker image to use, e.g. 'hsldevcom/jore-backend:latest'
 
       - name: Retrieve test results from docker container
+        if: always()
         run: docker cp robot-tests:/tests/output/. ${{ github.workspace }}/reports/
 
       - name: Expose test results as an artifact
+        if: always()
         uses: actions/upload-artifact@v1
         with:
           name: reports


### PR DESCRIPTION

Before results would be shown as green in github, even if tests fail. Updated readme accordingly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-robot/8)
<!-- Reviewable:end -->
