### PR TITLE
possibility to create docker images and run tests from development branches

### DIFF
--- a/.github/action/action.yml
+++ b/.github/action/action.yml
@@ -9,6 +9,10 @@ inputs:
     description: Version of backend to use (docker image tag)
     required: false
     default: ""
+  test_suite_version:
+    description: Which version of tests to use (docker image tag)
+    required: false
+    default: latest
   test_env:
     description: test environment name to select correct robot framework env variables
     required: false
@@ -46,6 +50,6 @@ runs:
       run: |
         docker run --name "robot-tests" \
           --network="host" \
-            hsldevcom/jore4-robot:latest \
+            hsldevcom/jore4-robot:${{ inputs.test_suite_version }} \
               bash -c "robot -v ENV:${{ inputs.test_env }} -v BROWSER:${{ inputs.browser }} --include ${{ inputs.included_tag }} --outputdir /tests/output /tests"
       shell: bash

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -3,8 +3,7 @@ on:
   push:
     branches:
       - main
-      - action_fix
-
+  pull_request:
   workflow_dispatch:
 
 jobs:
@@ -16,11 +15,30 @@ jobs:
       - name: checkout code
         uses: actions/checkout@v2
 
-      - name: Set local env variables
-        run: echo "ROBOT_IMAGE=hsldevcom/jore4-robot" >> $GITHUB_ENV
+      - name: Extract branch name to env variable
+        run: |
+          # In pull requests
+          BRANCH_NAME="${GITHUB_HEAD_REF}"
+          [[ ${BRANCH_NAME} = "" ]] && {
+            # In branch pushes
+            BRANCH_NAME="$(echo "${GITHUB_REF}" | cut -d '/' -f 3-)"
+          }
+          echo "BRANCH_NAME=${BRANCH_NAME}" >> "${GITHUB_ENV}"
+
+      - name: Set image name as environment variable
+        run: |
+          # Docker Hub uses lowercase so use a bashism to convert.
+          echo "IMAGE_NAME=${GITHUB_REPOSITORY,,}" >> $GITHUB_ENV
 
       - name: Build docker image
-        run: docker build -t $ROBOT_IMAGE .
+        run: docker build -t $IMAGE_NAME .
+
+      - name: Tag docker image as 'latest'
+        if: ${{ github.ref == 'refs/heads/main' }}
+        run: docker tag $IMAGE_NAME $IMAGE_NAME:latest
+
+      - name: Tag docker image as '<branch_name>
+        run: docker tag $IMAGE_NAME $IMAGE_NAME:$BRANCH_NAME
 
       - name: Login to DockerHub
         uses: docker/login-action@v1
@@ -28,5 +46,9 @@ jobs:
           username: ${{ secrets.JORE4_DOCKERHUB_USER }}
           password: ${{ secrets.JORE4_DOCKERHUB_TOKEN }}
 
-      - name: Push image to DockerHub
-        run: docker push $ROBOT_IMAGE
+      - name: Push image tagged with git commit details to Docker Hub
+        run: docker push $IMAGE_NAME:$BRANCH_NAME
+
+      - name: Push rest of the tags to Docker Hub
+        if: ${{ github.ref == 'refs/heads/main' }}
+        run: docker push $IMAGE_NAME:latest

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -15,40 +15,24 @@ jobs:
       - name: checkout code
         uses: actions/checkout@v2
 
-      - name: Extract branch name to env variable
-        run: |
-          # In pull requests
-          BRANCH_NAME="${GITHUB_HEAD_REF}"
-          [[ ${BRANCH_NAME} = "" ]] && {
-            # In branch pushes
-            BRANCH_NAME="$(echo "${GITHUB_REF}" | cut -d '/' -f 3-)"
-          }
-          echo "BRANCH_NAME=${BRANCH_NAME}" >> "${GITHUB_ENV}"
+      - name: Extract repository metadata to env variables
+        uses: HSLdevcom/jore4-tools/github-actions/extract-metadata@extract-metadata-v1
 
-      - name: Set image name as environment variable
-        run: |
-          # Docker Hub uses lowercase so use a bashism to convert.
-          echo "IMAGE_NAME=${GITHUB_REPOSITORY,,}" >> $GITHUB_ENV
+      - name: Build docker image for distribution
+        run: docker build -t $IMAGE_NAME:latest .
 
-      - name: Build docker image
-        run: docker build -t $IMAGE_NAME .
+      - name: Tag docker image as '<branch_name>--<git_commit_sha>'
+        run: docker tag $IMAGE_NAME:latest $IMAGE_NAME:$COMMIT_ID
 
-      - name: Tag docker image as 'latest'
-        if: ${{ github.ref == 'refs/heads/main' }}
-        run: docker tag $IMAGE_NAME $IMAGE_NAME:latest
-
-      - name: Tag docker image as '<branch_name>
-        run: docker tag $IMAGE_NAME $IMAGE_NAME:$BRANCH_NAME
-
-      - name: Login to DockerHub
+      - name: Login to Docker Hub
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.JORE4_DOCKERHUB_USER }}
           password: ${{ secrets.JORE4_DOCKERHUB_TOKEN }}
 
       - name: Push image tagged with git commit details to Docker Hub
-        run: docker push $IMAGE_NAME:$BRANCH_NAME
+        run: docker push $IMAGE_NAME:$COMMIT_ID
 
-      - name: Push rest of the tags to Docker Hub
+      - name: Push :latest tag to Docker Hub
         if: ${{ github.ref == 'refs/heads/main' }}
         run: docker push $IMAGE_NAME:latest

--- a/.github/workflows/trigger_tests_manually.yml
+++ b/.github/workflows/trigger_tests_manually.yml
@@ -14,6 +14,10 @@ on:
         description: 'Tag for tests to run. Use "*" to run all'
         default: smoke
         required: true
+      version:
+        description: "Which docker image you want to use"
+        default: latest
+
 jobs:
   run_e2e_tests:
     runs-on: ubuntu-20.04
@@ -28,6 +32,7 @@ jobs:
           test_env: ${{ github.event.inputs.env }}
           browser: ${{ github.event.inputs.browser }}
           included_tag: ${{ github.event.inputs.tag }}
+          test_suite_version: ${{ github.event.inputs.version }}
 
       - name: Retrieve test results from docker container
         if: always()


### PR DESCRIPTION
Cd.yml can be manually triggered to build docker image for development branch.
Test action takes robot containers docker image tag as input, defaults as latest if no input is given.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-robot/9)
<!-- Reviewable:end -->
