### PR TITLE
Fix stop creation test to work with the new flow

### DIFF
--- a/tests/Keywords/datetime_keywords.robot
+++ b/tests/Keywords/datetime_keywords.robot
@@ -10,4 +10,4 @@ set indefinite validity period
     [Arguments]    ${start_date}
     ${date_mmddyyyy}    Date as mmddyyyy    ${start_date}
     Type Text     ${ValidityStartInput}     ${date_mmddyyyy}
-    Click     ${IndefiniteCheckbox}
+    Check Checkbox     ${IndefiniteCheckbox}

--- a/tests/Keywords/routes_and_lines_keywords.robot
+++ b/tests/Keywords/routes_and_lines_keywords.robot
@@ -25,14 +25,14 @@ user adds a new bus stop
     [Documentation]   waits until network is idle, so that map is loaded properly
     Wait Until Network Is Idle
     Click    ${AddStopButton}    force=True
-    Click    ${MapGlMapBox}   position_x= 960    position_y= 540    force=True
+    user clicks on the map to create the stop
     edit new bus stop
-    validate stop creation responses
+    validate stop creation response
 
-validate stop creation responses
+user clicks on the map to create the stop
+    Click    ${MapGlMapBox}   position_x= 960    position_y= 540    force=True
     ${point_to_closest_link}   Wait For Response    ${HASURA_API_URL}
     ${point_direction_on_link}   Wait For Response    ${HASURA_API_URL}
-    ${insert_stop_point}   Wait For Response    ${HASURA_API_URL}
 
     ${point_to_link_json}   Dict to json    ${point_to_closest_link}[body]
     ${link_id}    Get value from response by key     ${point_to_link_json}   infrastructure_network_resolve_point_to_closest_link    infrastructure_link_id
@@ -42,14 +42,19 @@ validate stop creation responses
     ${point_direction}    Get value from response by key     ${point_direction_json}   infrastructure_network_find_point_direction_on_link    value
     Set Test Variable    ${DIRECTION}     ${point_direction}
 
+validate stop creation response
+    ${insert_stop_point}   Wait For Response    ${HASURA_API_URL}
+
     ${insert_stop_point_json}   Dict to json    ${insert_stop_point}[body]
     ${located_on_link}    Get value from response by key     ${insert_stop_point_json}   insert_service_pattern_scheduled_stop_point_one    located_on_infrastructure_link_id
     ${point_direction}          Get value from response by key     ${insert_stop_point_json}   insert_service_pattern_scheduled_stop_point_one    direction
+    ${label}          Get value from response by key     ${insert_stop_point_json}   insert_service_pattern_scheduled_stop_point_one    label
     Should Be Equal    ${point_direction}    ${DIRECTION}
     Should Be Equal    ${located_on_link}    ${LINK_ID}
+    Should Be Equal    ${label}    ${STOP_LABEL}
 
 edit new bus stop
-    Click    ${EditStopButton}    force=True
+    Click    ${StopInputLabelField}    force=True
     Fill Text   ${StopInputLabelField}    ${STOP_LABEL}
     ${latitude}     Get Text   ${StopLatitudeField}
     Set Test Variable    ${STOP_LATITUDE}    ${latitude}

--- a/tests/Resources/routes_and_lines_locators.robot
+++ b/tests/Resources/routes_and_lines_locators.robot
@@ -15,7 +15,11 @@ ${NewLineSaveButton}         //*[@id='save-button']
 #map modal
 ${AddStopButton}             //Button[text()='Lisää pysäkki']
 ${MapGlMapBox}               //*[contains(@class, 'maplibregl-map mapboxgl-map')]
+
+#stop popup
 ${EditStopButton}            //Button[text()='Muokkaa']
+
+#edit stop modal
 ${StopInputLabelField}        //input[contains(@name, 'label')]
 ${SaveStopButton}            //Button[text()='Tallenna']
 ${StopLatitudeField}         //*[@name='latitude']


### PR DESCRIPTION
1. the direction and closest link are already determined when the map is clicked, not only at saving
2. when placing a stop on the map, immediately the edit form is displayed, not only the popup

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-robot/20)
<!-- Reviewable:end -->
